### PR TITLE
Fix deprecation warning for `use Bitwise` in Elixir 1.14+

### DIFF
--- a/lib/utils/der.ex
+++ b/lib/utils/der.ex
@@ -1,7 +1,7 @@
 defmodule EllipticCurve.Utils.Der do
   @moduledoc false
 
-  use Bitwise
+  import Bitwise
 
   @hexAt "\x00"
   @hexB "\x02"

--- a/lib/utils/integer.ex
+++ b/lib/utils/integer.ex
@@ -1,7 +1,7 @@
 defmodule EllipticCurve.Utils.Integer do
   @moduledoc false
 
-  use Bitwise
+  import Bitwise
 
   def modulo(x, n) do
     rem(x, n)
@@ -33,18 +33,18 @@ defmodule EllipticCurve.Utils.Integer do
     #  We apply the mask to reduce the amount of attempts we might need
     #     to make to get a number that is in range. This is somewhat like
     #     the commonly used 'modulo trick', but without the bias:
-    #    
+    #
     #       "Let's say you invoke secure_rand(0, 60). When the other code
     #        generates a random integer, you might get 243. If you take
     #        (243 & 63)-- noting that the mask is 63-- you get 51. Since
     #        51 is less than 60, we can return this without bias. If we
     #        got 255, then 255 & 63 is 63. 63 > 60, so we try again.
-    #    
+    #
     #        The purpose of the mask is to reduce the number of random
     #        numbers discarded for the sake of ensuring an unbiased
     #        distribution. In the example above, 243 would discard, but
     #        (243 & 63) is in the range of 0 and 60."
-    #    
+    #
     #       (Source: Scott Arciszewski)
 
     randomNumber =


### PR DESCRIPTION
Hi there 👋 Nice library! 

I noticed a couple of deprecation warnings when running tests in a recent version:

```
mix test
Compiling 2 files (.ex)
warning: use Bitwise is deprecated. import Bitwise instead
  lib/utils/der.ex:4: EllipticCurve.Utils.Der (module)

warning: use Bitwise is deprecated. import Bitwise instead
  lib/utils/integer.ex:4: EllipticCurve.Utils.Integer (module)

.............
Finished in 0.06 seconds (0.00s async, 0.06s sync)
13 tests, 0 failures
```

I looked through the Elixir [changelog](https://github.com/elixir-lang/elixir/blob/v1.14/CHANGELOG.md#elixir-12) and discovered that `use Bitwise` is hard deprecated since 1.14.

This PR makes the recommended changes and imports the module instead.

---

On another topic — I wanted to check the backwards compatibility of this change. I started by running the tests against version `1.9`, which is the minimum stated compatible version in `mix.exs` but I encountered a compilation error:

```
== Compilation error in file lib/math.ex ==
** (CompileError) lib/math.ex:245: cannot invoke remote function p.y/0 inside guards
    (stdlib) lists.erl:1354: :lists.mapfoldl/3
```

Which refers to the following line:

```elixir
defp jacobianMultiply(p, _n, _cN, _cA, _cP) when p.y == 0 do
```

I decided to run tests against the `master` branch in a number of `hexpm/elixir` containers and the earliest tag that did not raise this compilation error is `1.11.0-erlang-21.0.1-debian-bullseye-20210902`.

I can confirm the `Bitwise` changes in this PR also result in a successful test run:

```
root@94fa891ce1c3:/srv# elixir -v
Erlang/OTP 21 [erts-10.0.1] [source] [64-bit] [smp:6:6] [ds:6:6:10] [async-threads:1]

Elixir 1.11.0 (compiled with Erlang/OTP 21)
root@94fa891ce1c3:/srv# mix test
.............

Finished in 0.1 seconds
13 tests, 0 failures

Randomized with seed 438621
```

So in addition to that change, I think it might be necessary to bump the minimum stated compatible version to `1.11`. In any case, this is the minimum supported version of Elixir (security patches only).
